### PR TITLE
improved deletion protection

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -104,18 +104,8 @@ create_backups () {
     ln -svf "${LAST_FILENAME}" "${BACKUP_DIR}/last/${DB}-latest${BACKUP_SUFFIX}"
 
     create_hardlinks "${FILE}" "daily"
-
-    if [ "${BACKUP_MONTH_DAY}" = "${MONTH_DAY}" ]
-    then
-
-      create_hardlinks "${FILE}" "monthly"
-
-    elif [ "${BACKUP_WEEK_DAY}" = "${WEEK_DAY}" ]
-    then
-
-      create_hardlinks "${FILE}" "weekly"
-
-    fi
+    create_hardlinks "${FILE}" "monthly"
+    create_hardlinks "${FILE}" "weekly"
 
     echo "SQL backup created successfully"
 

--- a/backup.sh
+++ b/backup.sh
@@ -208,12 +208,19 @@ cleanup_backups () {
     do
 
       #Clean old files
-      local all=( `find "${BACKUP_DIR}/${folder}" -maxdepth 1 -name "${DB}-*"` )
+      local all=( `find "${BACKUP_DIR}/${folder}" -maxdepth 1 -name "${DB}-*" | sort -t/ -k3` )
       local files=()
       number=$((${#all[@]}-$KEEP))
       echo "Number of Backups to be deleted: $number"
 
-      if [ $number -gt 0 ]
+      if [ $number -le 0 ]
+      then
+        
+        ecrit "Only ${#all[@]} Backups exist for ${DB} and you want to keep $KEEP."
+        ecrit "If you have just started taking backups you may ignore this"
+        ecrit "Otherwise you may want to investigate why backups are not being taken"
+
+      elif [ "$number" -gt 0 ]
       then
 
         local date=$(date +%Y%m%d --date "$keep days ago")
@@ -232,6 +239,15 @@ cleanup_backups () {
 
             files=( $backup )
 
+            ((number--))
+
+          fi
+
+          if [[ "$number" -le 0 ]]
+          then
+
+            break
+
           fi
 
         done
@@ -241,7 +257,7 @@ cleanup_backups () {
   	  for file in "${files[@]}"
       do
 
-        echo "Deleting $file"
+        echo "Deleting Backup: $file"
   		  rm $file
 
       done


### PR DESCRIPTION
The changes meant to protect against the situation where you want to keep 3 daily backups but you have a disruption where backups are not taken for a week. Under the old system when backups resumed then a new backup would taken and all old backups would be removed as they are older than 3 days leaving you with 1 backup.  Under the new system a new backup would be taken and all backups but the two newest backups would be removed leaving with 3 backups.